### PR TITLE
Implement policy as code for compliance checks

### DIFF
--- a/policy_as_code.tf
+++ b/policy_as_code.tf
@@ -1,0 +1,12 @@
+# policy_as_code.tf
+
+# Example policy as code using Sentinel
+import "tfplan"
+
+# Define a policy that checks for tags on all resources
+main = rule {
+    all tfplan.resources as resource {
+        resource.type is "aws_instance" implies
+            resource.applied.tags["Environment"] is not null
+    }
+}


### PR DESCRIPTION
This pull request introduces a new file `policy_as_code.tf` that defines a policy to ensure all AWS instances have an 'Environment' tag. This is part of the implementation for JIRA ticket KAN-2.