### PR TITLE
Add Playwright-Demo Environment

### DIFF
--- a/environments/playwright-demo/locals.tf
+++ b/environments/playwright-demo/locals.tf
@@ -1,0 +1,19 @@
+locals {
+  environment = "playwright-demo"
+  region      = "us-east-1"
+  
+  tags = {
+    Environment = local.environment
+    ManagedBy   = "Terraform"
+    Project     = "Landing Zone"
+  }
+
+  vpc_cidr = "10.2.0.0/16"  # Different CIDR range from dev
+  
+  accounts = {
+    demo = {
+      name  = "playwright-demo"
+      email = "aws-playwright-demo@yourdomain.com"
+    }
+  }
+}

--- a/environments/playwright-demo/outputs.tf
+++ b/environments/playwright-demo/outputs.tf
@@ -1,0 +1,14 @@
+output "vpc_id" {
+  description = "The ID of the VPC created in the playwright-demo environment."
+  value       = module.network.vpc_id
+}
+
+output "subnet_ids" {
+  description = "The IDs of the subnets created in the playwright-demo environment."
+  value       = module.network.subnet_ids
+}
+
+output "iam_role_arn" {
+  description = "The ARN of the IAM role created for the playwright-demo environment."
+  value       = module.accounts.iam_role_arn
+}

--- a/environments/playwright-demo/variables.tf
+++ b/environments/playwright-demo/variables.tf
@@ -1,0 +1,31 @@
+# This file declares the input variables for the playwright-demo environment.
+
+variable "vpc_cidr" {
+  description = "The CIDR block for the VPC"
+  type        = string
+  default     = "10.2.0.0/16"
+}
+
+variable "subnet_cidrs" {
+  description = "A list of CIDR blocks for the subnets"
+  type        = list(string)
+  default     = ["10.2.1.0/24", "10.2.2.0/24"]
+}
+
+variable "region" {
+  description = "The AWS region to deploy resources"
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "environment" {
+  description = "The environment name"
+  type        = string
+  default     = "playwright-demo"
+}
+
+variable "iam_role_name" {
+  description = "The name of the IAM role to create"
+  type        = string
+  default     = "playwright-demo-role"
+}

--- a/environments/playwright-demo/versions.tf
+++ b/environments/playwright-demo/versions.tf
@@ -1,0 +1,18 @@
+terraform {
+  required_version = ">= 1.0.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+
+  backend "s3" {
+    bucket         = "your-terraform-state-bucket"
+    key            = "playwright-demo/terraform.tfstate"
+    region         = "us-east-1"
+    dynamodb_table = "terraform-state-lock"
+    encrypt        = true
+  }
+}


### PR DESCRIPTION
This pull request adds a new environment named `playwright-demo` to the Terraform Landing Zone. The environment includes the following files:

- `locals.tf`: Defines local variables specific to the `playwright-demo` environment.
- `main.tf`: Currently empty, ready for resource definitions.
- `outputs.tf`: Outputs for VPC, subnets, and IAM role.
- `variables.tf`: Input variables for the environment.
- `versions.tf`: Specifies Terraform and provider versions, as well as backend configuration.

This environment is designed to support the Playwright-Demo use case.

Please review and merge.