### PR TITLE
Add new environment for KAN-17

### DIFF
--- a/environments/new_environment.tf
+++ b/environments/new_environment.tf
@@ -1,0 +1,14 @@
+# Terraform configuration for the new environment
+
+provider "aws" {
+  region = "us-west-2"
+}
+
+resource "aws_s3_bucket" "new_environment_bucket" {
+  bucket = "new-environment-bucket"
+  acl    = "private"
+}
+
+output "bucket_name" {
+  value = aws_s3_bucket.new_environment_bucket.bucket
+}


### PR DESCRIPTION
This pull request adds a new environment to the landing zone as per the requirements of ticket KAN-17. The changes include:

- Terraform configuration for a new AWS S3 bucket in the `us-west-2` region.

Closes KAN-17.